### PR TITLE
TODO - Conferir links de sites

### DIFF
--- a/src/flusp.tex
+++ b/src/flusp.tex
@@ -24,7 +24,7 @@ outros contribuírem, aqui você encontra espaço!
   \item[Facebook:] \url{facebook.com/flusp}
   \item[Telegram:] \url{http://tiny.cc/flusp}
   \item[IRC:] Servidor \texttt{irc.freenode.net}, canal \texttt{\#ccsl-usp}
-  \item[Site:] \url{https://flusp.ime.usp.br}
+  \item[Site:] \url{http://flusp.ime.usp.br}
   \item[Lista de email:] \texttt{flusp@googlegroups.com}
   \item[GitLab:] \url{https://gitlab.com/flusp}
 \end{description}


### PR DESCRIPTION
o site do flusp é http e não https, tem que mudar o link pra não dar erro de segurança