### PR TITLE
TODO - Revisar seção "Hospital Universitário"

### DIFF
--- a/src/hospital_universitario.tex
+++ b/src/hospital_universitario.tex
@@ -14,19 +14,26 @@ Biomédicas, de Biologia, de Química, a Faculdade de Arquitetura e Urbanismo,
 a Escola Politécnica e a Escola de Comunicações e Artes precisam de cobaias para
 suas atividades/experiências. O \sout{USPital} HU é um santo lugar que recebe alguns 
 fracos de espírito que bebem demais e ficam incapacitados de fazer qualquer 
-atividade fisiológica. Para fazer o cartão do hospital, vocês devem levar:
+atividade fisiológica. 
+
+Qualquer pessoa pode fazer seu cadastro no Hospital Universitário. Para isso, é 
+necessário comparecer pessoalmente ao hospital portando os seguintes documentos:
 
 \begin{itemize}
    \item a carteirinha USP;
    \item um documento oficial com foto (RG, CNH...);
-   \item o CPF; e
+   \item o CPF;
    \item o CNS (Cartão Nacional de Saúde, do SUS).
 \end{itemize}
 
+Os alunos da USP podem realizar esse cadastro a partir de um formulário 
+disponibilizado no site do HU: (\url{http://www.hu.usp.br/}). É nesse mesmo site 
+que você poderá agendar consultas e exames, cuide da sua saúde bixe!
+
 Assim vocês possuirão alguns privilégios no atendimento, em situações de
 emergência vocês são atendidos rapidamente (algo entre 600 minutos, como
-diz na senha de espera) e não precisam soletrar o nome da mãe enquanto
-estiverem desmaiados.
+diz na senha de espera). %e não precisam soletrar o nome da mãe enquanto
+%estiverem desmaiados.
 
 \begin{description}
 \item [Endereço:] Av. Prof. Lineu Prestes, 2565 - Butantã, São Paulo - SP, 05508-000


### PR DESCRIPTION
Adicionei que os alunos da USP podem fazer o cadastro no HU por um formulário e que as demais pessoas devem fazer isso pessoalmente. Retirei a frase que diz: "não precisam soletrar o nome da mãe enquanto estiverem desmaiados." na linhas 34 e 35.