### PR TITLE
TODO - Repassar texto para a Biblioteca

### DIFF
--- a/src/sobre_o_ime.tex
+++ b/src/sobre_o_ime.tex
@@ -151,11 +151,11 @@ do CCSL desse Guia!
 
 \begin{subsecao}{Biblioteca do IME-USP}
 
-A Biblioteca Carlos Benjamin de Lyra é uma das 48 bibliotecas da Agência USP de Informação Acadêmica (AGUIA). Considerada uma das maiores bibliotecas na Área de Matemática da América Latina, seu acervo é formado por livros, relatórios, revistas acadêmicas, teses, dissertações, trabalhos de docentes, CDs e DVDs totalizando cerca de 235.000 itens. 
+A Biblioteca Carlos Benjamin de Lyra é uma das 48 bibliotecas da Agência de Bibliotecas e Coleções Digitais da USP (ABCD). Considerada uma das maiores bibliotecas na área de matemática da América Latina, seu acervo é formado por livros, relatórios, revistas acadêmicas, teses, dissertações, trabalhos de docentes, CDs e DVDs, totalizando cerca de 235.000 itens. 
 
 \begin{subsubsecao}{Instalações:}
 
-O espaço físico da biblioteca é de 1.642m\textsuperscript{2}. Possui um amplo salão de estudos com mesas individuais, 13 salas para estudo em grupo e bancadas para estudo individual, totalizando 220 assentos.
+O espaço físico da biblioteca é de 1.642m\textsuperscript{2}. Possui um amplo salão de estudos com mesas individuais, 13 salas para estudo em grupo e bancadas para estudo individual, totalizando 221 assentos.
 \end{subsubsecao}
 
 \begin{subsubsecao}{Empréstimos:}
@@ -169,7 +169,7 @@ O aluno de graduação poderá emprestar 10 livros por 10 dias. Para o emprésti
 \vspace{-15pt}
 \begin{itemize}
     \item DEDALUS - é o catálogo online para consulta e localização dos materiais nos acervos das bibliotecas da USP e para renovação de empréstimos e pedidos de reservas. 
-    \item Portal de Busca Integrada - interface única para pesquisa de materiais impressos das bibliotecas e dos documentos disponíveis online, possibilitando o acesso a textos completos. 
+    \item Portal de Busca Integrada - interface única para pesquisa de materiais impressos das bibliotecas e dos documentos disponíveis online, possibilitando acesso a textos completos. 
     \item Bases de Dados e Portal Capes – acesso online a e-books e artigos de revistas assinadas pela USP e pela Capes.
     \end{itemize}
 \end{subsubsecao}
@@ -192,9 +192,9 @@ Além dos empréstimos, a Biblioteca possui scanner de autoatendimento e oferece
 \begin{subsubsecao}{Horário de funcionamento:}
 
 Período letivo: de 2ª a 6ª feira das 8h00 às 21h30 \newline
-\phantom{Período letivo: }de sábados das 9h00 às 13h00 \newline
+%\phantom{Período letivo: }de sábados das 9h00 às 13h00 \newline%
 Período não letivo: de 2ª a 6ª feira das 8h00 às 20h00 \newline
-\phantom{Período não letivo: }de sábados fechada 
+%\phantom{Período não letivo: }de sábados fechada%
 \end{subsubsecao}
 \begin{description}
   \item[Facebook:] \url{https://www.facebook.com/bibliotecaimeusp/}


### PR DESCRIPTION
Realizei as alterações solicitadas pela Biblioteca:
- Linha 154 substitui "Agência USP de Informação Acadêmica (AGUIA)" por "Agência de Bibliotecas e Coleções Digitais da USP (ABCD)."
- Linha 158 atualizei a quantidade de assentos para 221
- Linha 172 retirei o "o" de "possibilitando o acesso"
- Deixei como comentário as linhas 195 e 197, pois pelo que fui informada não ocorrerá atendimentos aos sábados nesse ano.