### PR TITLE
TODO - Revisar seção "Glossário"

### DIFF
--- a/src/glossario.tex
+++ b/src/glossario.tex
@@ -19,7 +19,7 @@ professor, que estuda um determinado assunto paralelamente ao curso. No caso de
 estudantes que queiram bolsas de estudo, é adotado um plano de estudos mais
 rigoroso.
 
-{\bf P1, P2, P3:} sofrimento de todo aluno de graduação. A quantidade de
+{\bf P1, P2, P3:} \sout{provas} sofrimento de todo aluno de graduação. A quantidade de
 sofrimento depende do professor da disciplina.
 
 {\bf SUB:} prova que você faz quando vai mal nas P1, P2 e P3, ou quando você
@@ -50,7 +50,7 @@ de entrega de EP''. Desenvolvido por Murphy.
 
 {\bf Stack Overflow:} mensagem que aparece na tela do computador
 quando ele se recusa a funcionar. Também é um site com todas as respostas
-para todas as peguntas sobre programação: \url{https://stackoverflow.com/}).
+para todas as peguntas sobre programação: \url{https://stackoverflow.com/}.
 
 {\bf Teorema Fundamental do EP:} ``O EP só funcionará no dia da entrega.'' Não
 confunda com o Corolário 42 da Lei de Murphy: ``O EP só {\bf não} funcionará no
@@ -72,7 +72,7 @@ todos os esportes que quiser.
 
 {\bf SAS:} Superintendência de Assistência Social. É onde estudantes fazem as
 carteirinhas de passe de ônibus, EMTU e metrô, além de solicitar os auxílios
-eteceteras que estão explicados na seção respectiva.
+eteceteras que estão explicados na respectiva seção.
 
 {\bf CRUSP:} Conjunto Residencial da USP. Se você se inscrever, torça para
 pegar um apartamento num dos blocos já reformados, ou então torça para não


### PR DESCRIPTION
Adicionei "provas" riscado por cima na definição de p1, p2 e p3 pq talvez não ficasse tão claro de qual tipo de sofrimento estávamos falando na definição kkkk 
Tirei o parenteses que estava sobrando no fim da linha 53  
Troquei "seção respectiva" por "respectiva seção" na linha 75 pq fica mais bonito assim