### PR TITLE
TODO - Revisar Bandejão na seção "Um pouco sobre a USP"

### DIFF
--- a/src/sobre_a_usp.tex
+++ b/src/sobre_a_usp.tex
@@ -301,14 +301,16 @@ problema para vocês no IME.
 Os bandejões, vulgarmente conhecidos como Restaurantes do SAS, são os lugares
 em que vocês podem se alimentar razoavelmente a um preço analogamente razoável.
 Os tickets custam R\$ 2,00, sendo estes carregados na carteirinha USP. O
-lugar para carregar o ``bandejão único'' é no SAS, perto do bandejão
-Central. Além disso, é possível verificar o saldo
-atual e comprar mais créditos via boleto no site
+lugar para carregar o ``bandejão único'' é no CARE (Centro USP de Acolhimento e 
+Referência para Estudantes), perto do SAS e do bandejão Central. Além disso, é 
+possível verificar o saldo atual e comprar mais créditos via boleto ou Pix no site
 {\tt https://uspdigital.usp.br/rucard/} ou pelo aplicativo ``Cardápio+ USP'',
 disponível para Android e iOS (não se esqueça de olhar também os outros
 aplicativos da USP disponíveis, pois podem ser muito úteis).
 É uma ótima alternativa para evitar as infinitas filas dos guichês de venda. Os
-créditos demoram até 03 (três) dias úteis para estarem disponíveis.
+créditos demoram até 03 (três) dias úteis para estarem disponíveis, caso vocês
+paguem via boleto. Se realizarem o pagamento pelo Pix, os créditos podem ser usados
+dentro de alguns minutos.
 Dica: Confira o saldo da carteirinha no site ou no aplicativo antes de tentar usar!
 
 Existe uma lenda que sobremesas especiais aparecem em certos bandejões perto de
@@ -319,61 +321,53 @@ cardápio (talvez para não ficar muito cheio de gente).
 
 O cardápio semanal do bandejão pode ser visto no site {\tt
 http://sites.usp.br/sas/} ou pelo aplicativo ``Cardápio+ USP'', mas se vocês
-estiverem com preguiça de ver em um desses lugares, é
-bem provável que um veterane já saiba e resolva informar se questionado com muita
-educação.
+estiverem com preguiça de ver em um desses lugares, é bem provável que um veterane 
+já saiba e resolva informar, se questionado com muita educação.
 
 O cardápio é geralmente composto de arroz (com opção normal e integral), feijão,
 prato principal (carne/ovos), acompanhamento (legumes ou verduras refogadas,
 cremes, molhos), salada (algumas folhas), sobremesa (frutas e/ou, às vezes, algo mais
 requintado), pãozinho (normal e integral) e suco (de diversos sabores: azul, vermelho,
-amarelo, etc.), além de temperos genéricos
-(jamais perguntem do que eles são feitos). Se vocês são vegetarianos, o
-acompanhamento nunca contém carne (e estão tentando fazer com que sejam veganos
-também), e todos os bandejões têm uma alternativa vegetariana de PVT para o
-prato principal, normalmente vindo na forma de ração, mas existindo as formas
-de lasanha, kibe, e outros.
+amarelo, etc.), além de temperos genéricos (jamais perguntem do que eles são feitos). 
+Se vocês são vegetarianos, o acompanhamento nunca contém carne (e estão tentando 
+fazer com que sejam veganos também), e todos os bandejões têm uma alternativa 
+vegetariana de PVT para o prato principal, normalmente vindo na forma de ração,
+mas existindo as formas de lasanha, kibe, e outros.
 
 
 Não se esqueçam de levar as suas canecas do Kit-bixe se forem comer nos
 bandejões, tanto para ostentar a posição de bixes do IME, quanto para salvar o
-meio ambiente, evitando o uso de copos descartáveis. Além disso, lembre de 
-levar a caneca, pois, devido à pandemia, não estão sendo disponibilizados
-copos descartáveis. %REFTIME%
+meio ambiente, evitando assim o uso de copos descartáveis. Os badenjões não 
+disponibilizam copos e não aceitam o uso de garrafas nas máquinas de suco, por 
+isso, é muito importante que vocês sempre tenham um copo ou caneca para conseguir 
+tomar o líquido colorido saborizado do bandeco.
 
 
-% PS: O Efeito Bandex é proporcional à quantidade de salitre utilizado em cada
-% bandejão.\\
-% PS 2: Nunca, em hipótese alguma, jamais, visite a cozinha do seu bandejão de
-% preferência, pois você corre o risco de nunca mais almoçar na vida. Como já
-% dizia o velho sábio ``A ignorância é uma virtude''.\\
-% PS 3: Playstation 3.
+PS: O Efeito Bandex é proporcional à quantidade de salitre utilizado em cada
+bandejão.\\
+PS 2: Nunca, em hipótese alguma, jamais, visite a cozinha do seu bandejão de
+preferência, pois você corre o risco de nunca mais almoçar na vida. Como já
+dizia o velho sábio ``A ignorância é uma virtude''.\\
+PS 3: Playstation 3.
 
-%Consultem a tabela abaixo para decidir em qual dos bandejões vocês vão comer.
+Consultem a tabela abaixo para decidir em qual dos bandejões vocês vão comer.
 
-% \begin{figure}[!htbp]
-% \begin{center}
-% 	\includegraphics{img/src/bandex.png}
-% \end{center}
-% \end{figure}
+\begin{figure}[!htbp]
+\begin{center}
+ 	\includegraphics{img/src/tabela bandeco.png}
+\end{center}
+\end{figure}
 
-O horário das refeições ANTES da pandemia da Covid-19 era o seguinte: %REFTIME %PANDEMIA
 
-Café da manhã: 7h às 8h30min (somente no Central, aos sábados fica aberto das
-7h às 9h e aos domingos das 8h às 9h30)\\
-Almoço: 11h15min às 14h15min (exceto de segunda a sexta na Química, que é das 11h às 14h)\\
-Jantar: 17h30 às 19h45 (não tem no PCO)\\
+O horário de funcionamento dos bandejões é o seguinte:
+Café da manhã: 7h às 8h30min (somente no Central, de segunda à sábado)\\
+Almoço: 11h15min às 14h15min (em todos os bandejões de segunda à sexta, de sábado 
+somente do Central e de domingo somente na Química)\\
+Jantar: 17h30 às 19h45 (somente na Química, na Física e no Central de segunda à sexta)\\
 
-Já o horário das refeições ATUALMENTE, ou seja, período em que vocês bixes 2022 estão 
-ingressando, é o seguinte:
-Café da manhã: 7h às 8h30min (somente no Central, de segunda a sexta; não sabemos se será
-oferecido aos fins de semana)\\
-Almoço: 11h15min às 14h15min (em todos os bandejões)\\
-Jantar: 17h30 às 19h45 (somente na Química, na Física e no Central)\\
-
-IMPORTANTE: o funcionamento dos bandejões pode ser alterado ao decorrer do ano, por isso
-recomendamos que vocês fiquem atentos ao aplicativo e às placas informativas presentes nos
-bandejões.
+IMPORTANTE: o funcionamento dos bandejões pode ser alterado ao decorrer do ano,
+principalmente nos feriados, por isso recomendamos que vocês fiquem atentos ao 
+aplicativo e às placas informativas presentes nos bandejões.
 
 Para mais informações, visitem o site do SAS: \url{http://sites.usp.br/sas/} ou
 utilizem o aplicativo ``Cardápio+ USP''.

--- a/src/sobre_a_usp.tex
+++ b/src/sobre_a_usp.tex
@@ -360,10 +360,10 @@ Consultem a tabela abaixo para decidir em qual dos bandejões vocês vão comer.
 
 
 O horário de funcionamento dos bandejões é o seguinte:
-Café da manhã: 7h às 8h30min (somente no Central, de segunda à sábado)\\
-Almoço: 11h15min às 14h15min (em todos os bandejões de segunda à sexta, de sábado 
+\textbf{Café da manhã:} 7h às 8h30min (somente no Central, de segunda à sábado)\\
+\textbf{Almoço:} 11h15min às 14h15min (em todos os bandejões de segunda à sexta, de sábado 
 somente do Central e de domingo somente na Química)\\
-Jantar: 17h30 às 19h45 (somente na Química, na Física e no Central de segunda à sexta)\\
+\textbf{Jantar:} 17h30 às 19h45 (somente na Química, na Física e no Central de segunda à sexta)\\
 
 IMPORTANTE: o funcionamento dos bandejões pode ser alterado ao decorrer do ano,
 principalmente nos feriados, por isso recomendamos que vocês fiquem atentos ao 

--- a/src/sobre_a_usp.tex
+++ b/src/sobre_a_usp.tex
@@ -354,7 +354,7 @@ Consultem a tabela abaixo para decidir em qual dos bandejões vocês vão comer.
 
 \begin{figure}[!htbp]
 \begin{center}
- 	\includegraphics{img/src/tabela bandeco.png}
+ 	\includegraphics{img/src/tabela_bandeco.png}
 \end{center}
 \end{figure}
 

--- a/src/sobre_a_usp.tex
+++ b/src/sobre_a_usp.tex
@@ -360,8 +360,8 @@ Consultem a tabela abaixo para decidir em qual dos bandejões vocês vão comer.
 
 
 O horário de funcionamento dos bandejões é o seguinte:
-\textbf{Café da manhã:} 7h às 8h30min (somente no Central, de segunda à sábado)\\
-\textbf{Almoço:} 11h15min às 14h15min (em todos os bandejões de segunda à sexta, de sábado 
+\textbf{Café da manhã:} 7h às 8h30 (somente no Central, de segunda à sábado)\\
+\textbf{Almoço:} 11h15 às 14h15 (em todos os bandejões de segunda à sexta, de sábado 
 somente do Central e de domingo somente na Química)\\
 \textbf{Jantar:} 17h30 às 19h45 (somente na Química, na Física e no Central de segunda à sexta)\\
 

--- a/src/sobre_a_usp.tex
+++ b/src/sobre_a_usp.tex
@@ -337,7 +337,7 @@ mas existindo as formas de lasanha, kibe, e outros.
 
 Não se esqueçam de levar as suas canecas do Kit-bixe se forem comer nos
 bandejões, tanto para ostentar a posição de bixes do IME, quanto para salvar o
-meio ambiente, evitando assim o uso de copos descartáveis. Os badenjões não 
+meio ambiente, evitando assim o uso de copos descartáveis. Os bandejões não 
 disponibilizam copos e não aceitam o uso de garrafas nas máquinas de suco, por 
 isso, é muito importante que vocês sempre tenham um copo ou caneca para conseguir 
 tomar o líquido colorido saborizado do bandeco.


### PR DESCRIPTION
- Linha 304, acrescentei o nome do lugar que recarrega saldo do bandeco que não é mais SAS (é só perto);
- Linha 306, acrescentei que agora é possível recarregar o saldo do bandeco através do pix;
- Linha 340, tirei a referência à pandemia;
- Linha 339, coloquei que garrafas também não podem ser usadas para tomar suco no bandeco;
- Linhas 345-350, coloquei o efeito bandex novamente no guia, pois agora temos uma nova tabela;
- Linha 356, acrescentei a tabela do bandeco e acho q vai dar problema, porque o nome está escrito com um espaço (tabela bandeco.png). Se isso for um problema adiciono a imagem novamente com o nome do arquivo sem espaço;
- Tirei o horário de funcionamento do bandejão durante a pandemia;
- Expecifiquei os dias da semana que funciona cada bandejão.