### PR TITLE
TODO - Repassar texto para a AAAMat

### DIFF
--- a/src/atletica.tex
+++ b/src/atletica.tex
@@ -18,18 +18,22 @@ Algumas das atividades da Atlética:
 Na AAAMat existem diretores de modalidade (DMs) que são pessoas responsáveis
 pelos treinos e campeonatos dos seguintes esportes: futebol de campo, futsal,
 basquete, vôlei, handebol, atletismo, natação, tênis de mesa, tênis de campo,
-xadrez, beisebol, softbol, ultimate frisbee, damas, bridge,
-rugby e e-sports (\textit{League of Legends}, \textit{Hearthstone},
-\textit{Counter Strike: Global Offense}, \textit{Brawl Stars},
+xadrez, beisebol, softbol, bridge, sinuca, truco, parkour, judô, karatê,
+kendô, jiu-jitsu, rugby e e-sports (\textit{League of Legends}, \textit{Osu!},
+\textit{Counter Strike: Global Offense}, \textit{Brawl Stars}, \textit{FIFA}
 \textit{Rocket League}, \textit{Clash Royale}, \textit{Valorant},
-\textit{Call of Duty: mobile}, e outros estão sempre surgindo). Além disso,
-contamos com a nossa amada BatIMEduca, bateria do IME juntamente com a Pedago.
+\textit{Call of Duty: mobile}, \textit{Just Dance}, \textit{Hearthstone},
+\textit{Pokemon UNITE}, \textit{Rainbow 6}, \textit{Super Smash Bros},
+\textit{Teamfight Tactics}, \textit{Mario Kart},, \textit{Overwatch 2},
+\textit{Legends of Runeterra}, \textit{Wild Rift} e outros estão sempre surgindo).
+Além disso, contamos com a nossa amada BatIMEduca, bateria do IME juntamente
+com a Pedago.
 
 Os dias e horários dos treinos/jogos de cada uma dessas modalidades serão
 sempre informados através do site e do mural da Atlética, localizado na entrada
 do bloco B (aquele mural verde colado na parede em frente à lanchonete).
 Vocês também podem entrar em contato pelas nossas redes sociais ou diretamente
-na página da modalidade (todas estão na nossa bio do Instagram),
+na página da modalidade (todas estão na nossa bio do Instagram).
 
 Com essa variedade de modalidades, não tem desculpa pro sedentarismo hein,
 bixe? Se você não conhece nenhuma delas, a gente te apresenta e se já conhece,
@@ -128,7 +132,9 @@ conquistas que virão esse ano:
     2017 & Rugby Feminino (IME+EEFE)\\
     2018 & Xadrez\\
     2018 & Futebol de Campo Feminino\\
-    2022 & BORA BIXES!!!!\\
+    2022 & Xadrez\\
+    2022 & Natação Feminino (IME+ICBIÓ)\\
+    2023 & BORA BIXES!!!!\\
     \hline
   \end{tabular}
 \end{center}
@@ -208,7 +214,7 @@ Nosso histórico neste Inter é de parar o trânsito! Olhem só:
    2018 & Casa Branca & FAU\\
    2019 & Franca & FFLCH\\
    2020 & On-line & AAAGW\\
-   2021 & On-line & IME!!\\
+   2021 & On-line & IME\\
    2022 & Itapeva & ICBIÓ\\
    2023 & VAMO IME!!! & \\
    \hline
@@ -217,9 +223,9 @@ Nosso histórico neste Inter é de parar o trânsito! Olhem só:
 
 %REFTIME
 Em 2020 e 2021, o BIFE se reinventou trazendo o inter de maneira on-line, através do
-E-Bife, em que rolaram jogos dos e-sports e também algumas festas. E na última edição,
-nós saímos como CAMPEÕES!!!!! Nossos times contam com vocês para conquistar mais um
-título em 2022! VAMO QUE VAMO, GALERA!!!
+E-Bife, em que rolaram jogos dos e-sports e também algumas festas. Na última edição, 
+a primeira presencial após a pandemia, nós ficamos em  4º!!!!! Nossos times contam
+com vocês para conquistar mais um título em 2023! VAMO QUE VAMO, GALERA!!!
 
 
 \end{subsecao}
@@ -252,11 +258,17 @@ abaixo algumas de nossas conquistas:
     2018 & Jogos da Liga  & Basquete Masc.  & 2º\\
     2018 & Jogos da Liga Série Prata  & Basquete Masc.  & 1º\\
     2019 & BIFE           & Basquete Masc.  & 1º\\
+    2022 & BIFE           & Basquete Masc.  & 2º\\
     2020 & E-BIFE         & Brawl Stars     & 1º\\
-    2021 & E-BIFE         & Brawl Stars     & 1°\\
+    2021 & E-BIFE         & Brawl Stars     & 1º\\
     2020 & E-BIFE         & Clash Royale    & 1º\\
-    2021 & E-BIFE         & Clash Royale    & 1°\\
-    2021 & E-BIFE         & CSGO            & 3°\\
+    2021 & E-BIFE         & Clash Royale    & 1º\\
+    2021 & E-BIFE         & CSGO            & 3º\\
+    2018 & BIFE           & E-Sports        & 1º\\
+    2019 & BIFE           & E-Sports        & 2º\\
+    2020 & E-BIFE         & E-Sports        & 2º\\
+    2021 & E-BIFE         & E-Sports        & 1º\\
+    2022 & BIFE           & E-Sports        & 1º\\
     2015 & Integramix     & Futebol Campo   & 1º\\
     2017 & Copa USP       & Futebol Campo M & 1º\\
     2018 & BIFE           & Futebol Campo F & 2º\\
@@ -265,6 +277,7 @@ abaixo algumas de nossas conquistas:
     2017 & Copa USP       & Futsal Fem.     & 1º\\
     2017 & Jogos da Liga  & Futsal Fem.     & 2º\\
     2017 & IMEACHECA      & Futsal Fem.     & 1º\\
+    2022 & Interatléticas & Futsal Fem.     & 2º\\
     2011 & Copa USP       & Futsal Masc.    & 1º\\
     2012 & Copa Camp      & Futsal Masc.    & 1º\\
     2013 & NDU            & Futsal Masc.    & 1º\\
@@ -289,17 +302,19 @@ abaixo algumas de nossas conquistas:
     2012 & Copa USP       & Handebol Masc.  & 2º\\
     2016 & IMEACHECA      & Handebol Masc.  & 2º\\
     2018 & Jogos da Liga  & Handebol Masc.  & 2º\\
+    2022 & BIFE           & Handebol Masc.  & 1º\\
     2017 & TUES           & Hearthstone     & 2º\\
     2020 & E-BIFE         & Hearthstone     & 1º\\
     2017 & Copa USP       & Jiu-jitsu       & 2º\\
-    2021 & E-BIFE         & LOL             & 2°\\
+    2022 & BIFE           & Judô Masc.      & 2º\\
+    2021 & E-BIFE         & LOL             & 2º\\
     2018 & BIFE           & Natação Masc.   & 2º\\
     2018 & Jogos da Liga  & Natação Masc.   & 2º\\
     2019 & BIFE           & Natação Masc.   & 3º\\
-    2021 & E-BIFE         & Rocket League   & 2°\\
+    2021 & E-BIFE         & Rocket League   & 2º\\
     2018 & BIFE           & Rugby Masc.     & 2º\\
     2017 & Jogos da Liga  & Tênis Campo M   & 2º\\
-    2021 & E-BIFE         & Valorant        & 2°\\
+    2021 & E-BIFE         & Valorant        & 2º\\
     2016 & IMEACHECA      & Vôlei Fem.      & 1º\\
     2016 & Gran Prix USP  & Vôlei Fem.      & 3º\\
     2017 & Gran Prix USP  & Vôlei Fem.      & 3º\\
@@ -314,7 +329,8 @@ abaixo algumas de nossas conquistas:
     2017 & Copa USP       & Xadrez          & 3º\\
     2017 & Jogos da Liga  & Xadrez          & 2º\\
     2020 & E-BIFE         & Xadrez          & 1º\\
-    2021 & E-BIFE         & Xadrez          & 1°\\
+    2021 & E-BIFE         & Xadrez          & 1º\\
+    2022 & BIFE           & Xadrez          & 3º\\
     \hline
   \end{tabular}
 \end{center}
@@ -360,11 +376,16 @@ Para ficarem sabendo tudo que acontece na atlética é só:
 \begin{itemize}
   \item Acompanhar o site da atlética: \url{https://atletica.ime.usp.br}
   \item Curtir nossa página no Facebook: \url{https://fb.com/aaamat.ime}
-  \item Seguir a gente no Instagram: @aaamat\_imeusp
+  \item Seguir a gente no Instagram: @atleticaimeusp
 \end{itemize}
 
 %REFTIME
-A Atlética inicia 2022 esperando vocês, bixes querides, para que juntos
+Talvez vocês notem que existem outros dois instas antigos da AAAMat
+(@aaamat\_imeusp e @atleticaime), ambos desses já não são mais utilizados
+e se algum bixe souber como derrubar essas contas, fale para a atlética, 
+pois a gestão será eternamente agradecida pela sua ajuda! 
+
+A Atlética inicia 2023 esperando vocês, bixes querides, para que juntos
 possamos trazer muitos títulos e troféus para casa!! É importantíssimo que
 vocês saibam que estamos abertos para qualquer tipo de crítica, dúvida, ideia
 ou sugestão.


### PR DESCRIPTION
Retirei ultimate frisbee e damas (os dois morreram) e adicionei todas as modalidades que faltavam nas linhas 19-28 Troquei virgula por ponto na linha 36
Adicionei xadrez e natacao feminino no bichusp 2022 e bora bixes no bichusp 2023 Retirei as exclamações na linha 217
Arrumei o texto 225-228 condizente com o ultimo resultado do bife Adicionei o segundo lugar do basquete masc na linha 261, add o segundo lugar do futsal fem na linha 275, add o primeiro lugar do hand masc na linha 300, add o terceiro lugar do xadrez na linha 328, add a modalidade e-sports nas linhas 267-271 com os resultados desde 2018, pois em lugar nenhum constavam os resultados gerais Adicionei um texto (378-381) falando sobre os instagrams antigos que nao sao mais utilizados, como a atlética pediu Mudei 2022 pra 2023 na linha 383

Não sei se as tabelas estão cabendo certinho na página, por favor alguém verifica ;-;