### PR TITLE
Revisão seção "Eduroam"

### DIFF
--- a/src/sobre_a_usp.tex
+++ b/src/sobre_a_usp.tex
@@ -79,9 +79,9 @@ link e fazer parte dos grupos de whats das matérias que você está cursando!! 
 
 O Eduroam (EDUcation ROAMing, não tem nada a ver com alguém chamado Eduardo) é um
 serviço de wi-fi que \sout{às vezes} provê acesso à Internet dentro de diversas
-universidades (inclusive a USP). Mesmo que você seja aluno da USP, se viajar para
-outra universidade, no Brasil ou no exterior, que possui o Eduroam, ainda poderá ter
-acesso à Internet usando o mesmo login!
+universidades (inclusive a USP). Mesmo que você seja apenas aluno da USP, se viajar
+para outra universidade, no Brasil ou no exterior, que possui o Eduroam, ainda poderá
+ter acesso à Internet usando o mesmo login!
 
 Para usar o Eduroam, basta se conectar à rede \texttt{eduroam}, colocando no campo
 de login o seu número USP seguido por @usp.br. Por exemplo, se o seu número USP for
@@ -91,9 +91,9 @@ para logar no Jupiterweb).
 
 Tem várias outras informações sobre as configurações na hora de fazer login que
 \sout{ninguém entende, mas se algum de vocês entender,} estão no site
-\url{https://eduroam.usp.br/como-usar/}.
-
-Para mais informações, acessem \url{https://eduroam.usp.br/}.
+\url{https://eduroam.usp.br/como-usar/}. Também costumam haver cartazes
+espalhados pelo IME com os detalhes de login para diferentes tipos de dispositivo,
+então deem uma olhada nas paredes.
 
 \end{subsecao}
 


### PR DESCRIPTION
- Acrescentei um "apenas" para deixar claro que você pode usar o eduroam mesmo não sendo da outra faculdade
- Mencionei os cartazes com as instruções para login espalhados pelo ime
- Retirei a segunda menção ao mesmo site, estava redundante