### PR TITLE
Revisão seção "Tudo que vai volta"

### DIFF
--- a/src/transporte.tex
+++ b/src/transporte.tex
@@ -6,15 +6,16 @@ Se vocês não têm como ir nem como voltar, temos algumas dicas:
 
 \begin{enumerate}
 \vspace{-15pt}
-  \item Trabalhem muito para comprar um carro,
-  trabalhem mais para pagar a gasolina,
-  venham para a USP de carro e, obrigatoriamente, deem carona a um veterane;
+  \item Trabalhem muito para comprar um carro, trabalhem mais para pagar a
+  gasolina, venham para a USP de carro e, obrigatoriamente, deem carona a um
+  veterane;
 
   \item Peçam a uma pessoa amiga para trazê-los e buscá-los durante seus
   longos anos de IME;
 
-  \item Conheça alguém que, por sorte, mora perto da sua casa, estuda na USP,
-  tenha o mesmo horário que você, seja legal e tenha carro. Traduzindo, s-o-n-h-e;
+  \item Conheçam alguém que, por sorte, more perto da sua casa, estude na USP,
+  tenha o mesmo horário que você, seja legal e tenha carro.
+  Traduzindo: s-o-n-h-e;
 
   \item Estiquem o dedão e esperem, esperem, esperem, esperem... a boa vontade
   de alguém para dar carona;
@@ -36,22 +37,21 @@ provavelmente estão em uma das seguintes opções:
 Se vocês vão usar ônibus para ir ou voltar da USP, vocês precisam conhecer
 os quatro pontos de ônibus perto do IME: FAU I, Oceanografia, FAU II e FEA.
 Até 2019, esses quatro pontos tinham placas com os nomes escritos, mas
-agora foram reformados e não têm mais as placas. Mesmo assim, a localização deles
-não poderia ser mais intuitiva, veja só:
+agora foram reformados e não têm mais as placas. Mesmo assim, a localização
+deles não poderia ser mais intuitiva, veja só:
 
 Tanto o ponto FAU I quanto o ponto da Oceanografia se localizam na Rua do
-Matão - FAU I é o ponto que fica mais próximo da FAU, e o da Oceanografia é o
+Matão -- FAU I é o ponto que fica mais próximo da FAU, e o da Oceanografia é o
 que fica do mesmo lado da calçada que o IO (pronuncia-se i-ó), Instituto de
 Oceanografia; os pontos FAU II e FEA ficam na Av. Prof. Luciano Gualberto (que a
 partir de agora será chamada de Rua dos Bancos, para todo e todo o sempre),
-e, como você já deve estar imaginando, são na frente da FAU e da FEA,
+e, como vocês já devem estar imaginando, são na frente da FAU e da FEA,
 respectivamente. São muitos nomes para lembrar? Fiquem tranquilos: mais
 cedo ou mais tarde vocês vão conhecer esses lugares e não vão nem se preocupar
 mais com os nomes.
 
-
-Como você viu ali em cima, nós damos apelidos também intuitivos para as principais
-avenidas do campus:
+Como vocês viram ali em cima, nós damos apelidos também intuitivos para as
+principais avenidas do campus:
 \begin{itemize}
 	\item Av. Prof. Luciano Gualberto = Rua dos Bancos;
 	\item Av. Prof. Lineu Prestes = Rua do HU;
@@ -150,36 +150,37 @@ Novamente, esses quatro ônibus passam no ponto, mas estão CHEGANDO na USP!
 	\end{tabular}
 \end{center}
 
-As linhas marcadas com um * são as linhas circulares da SPTrans. Segue abaixo suas descrições!
+As linhas marcadas com um * são as linhas circulares da SPTrans.
+Segue abaixo suas descrições!
 
 \end{subsubsecao}
 
 \begin{subsubsecao}{Circulares}
 
-Também conhecido como ``circulenda'' ou ``secular'' (aos sábados, ``milenar'',
-e aos domingos, ``anos-luz''), é o meio de transporte mais barato dentro da USP.
-Foi criado para os USPianos se locomoverem dentro do Campus, mas em muitas vezes
-é melhor andar do que ficar esperando. Existem 3 itinerários distintos: 2 deles têm
-trajetos aproximadamente reversos e que cobrem todo o Campus, e o outro é uma "versão
-expressa" de um deles, que só passa pelas partes do Campus que ficam entre os portões
-P1 e P2 (isso inclui o IME, como vocês devem ter visto na tabela do ponto da FEA aí
-em cima). Isso já vai ser explicado melhor. Fiquem atentos para não se perderem, hein?
+Também conhecido como ``circulenda'' ou ``secular'' (aos sábados e domingos,
+``milenar''), é o meio de transporte mais barato dentro da USP. Foi criado para
+os USPianos se locomoverem dentro do Campus, mas em muitas vezes é melhor andar
+do que ficar esperando. Existem 3 itinerários distintos: 2 deles têm trajetos
+aproximadamente reversos e que cobrem todo o Campus, e o outro é uma
+"versão expressa" de um deles, que só passa pelas partes do Campus que ficam
+entre os portões P1 e P2 (isso inclui o IME, como vocês devem ter visto na
+tabela do ponto da FEA aí em cima). Isso já vai ser explicado melhor. Fiquem
+atentos para não se perderem, hein?
 
-Em 2012 foram implantadas as linhas 8012/10 (circular 1) e 8022/10 (circular 2); mais recentemente, em abril de 2019, foi
-criada a linha 8032/10 (circular 3). Essas linhas funcionam
-dentro da USP, e nós alunos não pagamos, pois elas aceitam o bilhete USP
-(BUSP - Retire logo o seu!!).
+Em 2012 foram implantadas as linhas 8012/10 (circular 1) e 8022/10 (circular 2);
+mais recentemente, em abril de 2019, foi criada a linha 8032/10 (circular 3).
+Essas linhas funcionam dentro da USP, e nós alunos não pagamos, pois elas
+aceitam o bilhete USP (BUSP -- Retire logo o seu!!).
 
 %REFTIME
-Em 2021 houve uma grande mudança no trajeto dos circulares, porque agora eles têm um
-ponto final no Portão 3 (e tecnicamente não são mais circulares, será que o nome vai ficar?).
-Como essa mudança ocorreu durante a pandemia, até mesmo veteranes podem ser surpreendidos,
-então prestem atenção nos mapas!
+Em 2021 houve uma grande mudança no trajeto dos circulares, porque agora eles
+têm um ponto final no Portão 3 (e tecnicamente não são mais circulares, será que
+o nome vai ficar?). Como essa mudança ocorreu durante a pandemia, até mesmo
+veteranes podem ser surpreendidos, então prestem atenção nos mapas!
 
-Para acompanharem as rotas dos circulares e acompanhá-los em tempo real, bem como
-ver os portões do campus que estão abertos e seu horário de funcionamento, pode-se
-usar o aplicativo “Portões USP", disponível para Android e escrito por ex-alunos
-do IME.
+Para acompanharem as rotas dos circulares em tempo real, bem como ver pontos
+importantes da faculdade, podem usar o aplicativo ''Guia USP", disponível para
+Android e iOS.
 
 Para os bixes que não gostam de ler (preferem imagens) colocamos o
 mapa das três linhas nas próximas páginas.
@@ -194,28 +195,32 @@ mapa das três linhas nas próximas páginas.
 
 \begin{subsubsecao}{Como ir e vir do IME pelo metrô Butantã}
 
-Como sabemos que vocês, bixes, chegam muito perdidos, e muitos pularam todas essas informações
-sobre os pontos de ônibus e por isso podem não saber como fazer seu trajeto, resolvemos colocar
-aqui um dos trajetos mais comuns que boa parte de vocês vão usar.
+Como sabemos que vocês, bixes, chegam muito perdidos, e muitos pularam todas
+essas informações sobre os pontos de ônibus e por isso podem não saber como
+fazer seu trajeto, resolvemos colocar aqui um dos trajetos mais comuns que boa
+parte de vocês vão usar.
 
-Para chegar no IME a partir do metrô Butantã, vocês devem pegar o circular 1 (8012-10) ou o
-circular 3 (8032-10). Se vocês pegarem o circular 2 (8022-10), em algum momento vocês vão
-chegar no IME, mas os circulares 1 e 3 são muito mais rápidos.
+Para chegar no IME a partir do metrô Butantã, vocês devem pegar o circular 1
+(8012-10) ou o circular 3 (8032-10). Se vocês pegarem o circular 2 (8022-10),
+em algum momento vocês vão chegar no IME, mas os circulares 1 e 3 são muito mais
+rápidos.
 
-O circular 1 vai fazer o seguinte trajeto: Faculdade de Educação, CEPEUSP, Praça do Relógio
-Solar, Biblioteca Brasiliana e Faculdade de Economia, Administração e Contabilidade. A partir
-daí, deverão descer no ponto da FEA. O circular 3 faz praticamente o mesmo trajeto até o IME,
-sem passar pela Praça do Relógio Solar - isso não significa que você vai sempre demorar
+O circular 1 vai fazer o seguinte trajeto: Faculdade de Educação, CEPEUSP,
+Praça do Relógio Solar, Biblioteca Brasiliana e Faculdade de Economia,
+Administração e Contabilidade (FEA). A partir daí, deverão descer no ponto da
+FEA. O circular 3 faz praticamente o mesmo trajeto até o IME, sem passar pela
+Praça do Relógio Solar -- mas isso não significa que você vai sempre demorar
 menos para chegar no IME se pegar o circular 3 em vez do 1!
 
-Quando estiverem indo embora, vocês têm duas boas opções: pegar o circular 2 (8022-10) no
-ponto da Oceanografia, ou o circular 3 (8032-10) no ponto da FEA. CUIDADO: não peguem o
-circular 1 aqui se estiverem querendo ir para o metrô Butantã!!! Lembrem que ele passa na FEA
-logo no começo do trajeto (e provavelmente foi nesse ponto que vocês desceram do ônibus quando
-chegaram). Se vocês pegarem o circular 1 (8012-10) no ponto FAU I, também vão (em algum
-momento) chegar no metrô Butantã, mas boatos dizem que os outros circulares vão mais rápido.
-Aí, basta ficar no ônibus sentado (se conseguir um lugar!) até chegar no metrô Butantã, onde
-todos do ônibus vão descer.
+Quando estiverem indo embora, vocês têm duas boas opções: pegar o circular 2
+(8022-10) no ponto da Oceanografia, ou o circular 3 (8032-10) no ponto da FEA.
+CUIDADO: não peguem o circular 1 aqui se estiverem querendo ir para o metrô
+Butantã!!! Lembrem que ele passa na FEA logo no começo do trajeto
+(e provavelmente foi nesse ponto que vocês desceram do ônibus quando chegaram).
+Se vocês pegarem o circular 1 (8012-10) no ponto FAU I, também vão (em algum
+momento) chegar no metrô Butantã, mas boatos dizem que os outros circulares vão
+mais rápido. Aí, basta ficar no ônibus sentado (se conseguir um lugar!) até
+chegar no metrô Butantã, onde todos do ônibus vão descer.
 
 \end{subsubsecao}
 
@@ -223,9 +228,9 @@ todos do ônibus vão descer.
 
 Agora, se vocês moram mais longe ainda (outra cidade, outro estado, outro país,
 outra dimensão...) e não querem ou não podem se mudar para São Paulo, existem
-algumas linhas de ônibus fretados para cidades mais próximas (ou não). Se a cidade
-de vocês não estiver aí, procurem se informar a respeito, pois não significa
-necessariamente que não haja ônibus da USP para lá. Aí estão elas:
+algumas linhas de ônibus fretados para cidades mais próximas (ou não). Se a
+cidade de vocês não estiver aí, procurem se informar a respeito, pois não
+significa necessariamente que não haja ônibus da USP para lá. Aí estão elas:
 
 \begin{itemize}
   \item {\bf Empresa Urubupungá}\\
@@ -263,48 +268,51 @@ necessariamente que não haja ônibus da USP para lá. Aí estão elas:
 
 \begin{subsecao}{Horário dos Portões: Veículos no Campus}
 
-Saibam por onde entrar na USP. Lembrem-se de terem sempre a carteirinha USP, e-Card
-ou comprovante de matrícula com RG em mãos, pois pode ser solicitado principalmente
-nos horários de entrada controlada.
+Saibam por onde entrar na USP. Lembrem-se de terem sempre a carteirinha USP, ou
+o e-Card no celular, ou o comprovante de matrícula (nos primeiros dias), além de
+RG e, por garantia, o comprovante de vacinação em mãos, pois esses documentos
+podem ser solicitados principalmente nos horários de entrada controlada.
 \begin{itemize}
   \item {\bf Portaria 1 (P1):} R. Afrânio Peixoto. Funciona 24h por dia todos os
-    dias, mas a entrada é controlada para pedestres e carros nos seguintes horários:
-    todos os dias das 20h às 5h, aos sábados após as 14h, aos domingos e feriados o
-    dia inteiro. É por onde entram os ônibus municipais.
+    dias, mas a entrada é controlada para pedestres e carros nos seguintes
+    horários: todos os dias das 20h às 5h, aos sábados após as 14h, aos domingos
+    e feriados o dia inteiro. É por onde entram os ônibus municipais.
 
-  \item {\bf Portaria 2 (P2):} Av. Escola Politécnica. De segunda a sexta, acesso
-  livre das 5h às 20h e controlado das 20h às 0h. Aos sábados, liberada somente para
-  pedestres das 5h às 14h e controlada somente para pedestres das 14h às 0h.
-  Fechada aos sábados (para veículos), domingos e feriados. Única entrada para caminhões.
+  \item {\bf Portaria 2 (P2):} Av. Escola Politécnica. De segunda à sexta,
+  acesso livre das 5h às 20h e controlado das 20h às 0h. Aos sábados, acesso
+  somente para pedestres: liberado das 5h às 14h e controlado das 14h às 0h.
+  Fechada aos sábados (para veículos), domingos e feriados. Única entrada para
+  caminhões.
 
-  \item {\bf Portaria 3 (P3):} Av. Corifeu de Azevedo Marques. Tem o mesmo horário
-    de funcionamento do P1 para os pedestres. Para os carros, tem o mesmo horário do P1
-    exceto aos domingos, feriados e madrugadas (0h às 5h), nas quais ele fecha, ao
-    contrário do P1.
+  \item {\bf Portaria 3 (P3):} Av. Corifeu de Azevedo Marques. Tem o mesmo
+  	horário de funcionamento do P1 para os pedestres. Para os carros, tem o
+  	mesmo horário do P1 exceto aos domingos, feriados e madrugadas (0h às 5h),
+  	nas quais ele fecha, ao contrário do P1.
 
-  \item {\bf Portaria P' (Plinha):} R. Eng. Teixeira Soares. Funciona de segunda a
-  sexta das 6h às 18h. Fechado de sábados, domingos e feriados.
+  \item {\bf Portaria P' (Plinha):} R. Eng. Teixeira Soares. Funciona de segunda
+  à sexta das 6h às 18h. Fechado de sábados, domingos e feriados.
 
   \item {\bf Portarias de pedestre (Mercadinho, São Remo, HU, CPTM e
-      Vila Indiana):} Funcionam de segunda a sexta das 5h às 20 h, e de sábado das 5h às 14h.
-      Acesso controlado de segunda a sexta das 20h às 0h. Nas portarias do Mercadinho e Vila
-      Indiana, pode entrar em quaisquer outros horários, incluindo domingos e feriados, mas o
-      acesso é controlado.
+      Vila Indiana):} Funcionam de segunda à sexta das 5h às 20h, e de sábado
+      das 5h às 14h. Acesso controlado de segunda à sexta das 20h às 0h.
+      Nas portarias do Mercadinho e Vila Indiana, pode entrar em quaisquer
+      outros horários, incluindo domingos e feriados, mas o acesso é controlado.
 
 \end{itemize}
 
-As linhas de ônibus municipais que passam por dentro da USP não operam aos finais de semana,
-com exceção aos circulares, que entram na Universidade a qualquer hora, e à linha 702U (Term.
-Pq. D. Pedro II - Cid. Universitária), que funciona todos os dias das 5h às 0h
-(aproximadamente!). Se vocês vêm de carro, saibam que a universidade dispõe de bolsões de
-estacionamento gratuito em torno das Unidades.
+As linhas de ônibus municipais que passam por dentro da USP não operam aos
+finais de semana, com exceção dos circulares, que entram na Universidade a
+qualquer hora, e da linha 702U (Term. Pq. D. Pedro II - Cid. Universitária), que
+funciona todos os dias das 5h às 0h (aproximadamente!). Se vocês vêm de carro,
+saibam que a universidade dispõe de bolsões de estacionamento gratuito em torno
+das Unidades.
 
 \end{subsecao}
 \pagebreak
 \begin{subsecao}{Pontos de táxi}
 Existem alguns pontos de táxi espalhados pela Cidade Universitária. As frotas
-operam de segunda a sexta-feira, das 7h às 23h, além de aos sábados, das 7h às 17h.
-Eis suas localidades:
+operam de segunda à sexta-feira, das 7h às 23h, além de aos sábados, das 7h às
+17h. Eis suas localidades:
 
 \begin{itemize}
 \item Praça das Agências Bancárias\\

--- a/src/transporte.tex
+++ b/src/transporte.tex
@@ -162,7 +162,7 @@ Também conhecido como ``circulenda'' ou ``secular'' (aos sábados e domingos,
 os USPianos se locomoverem dentro do Campus, mas em muitas vezes é melhor andar
 do que ficar esperando. Existem 3 itinerários distintos: 2 deles têm trajetos
 aproximadamente reversos e que cobrem todo o Campus, e o outro é uma
-"versão expressa" de um deles, que só passa pelas partes do Campus que ficam
+``versão expressa" de um deles, que só passa pelas partes do Campus que ficam
 entre os portões P1 e P2 (isso inclui o IME, como vocês devem ter visto na
 tabela do ponto da FEA aí em cima). Isso já vai ser explicado melhor. Fiquem
 atentos para não se perderem, hein?
@@ -179,7 +179,7 @@ o nome vai ficar?). Como essa mudança ocorreu durante a pandemia, até mesmo
 veteranes podem ser surpreendidos, então prestem atenção nos mapas!
 
 Para acompanharem as rotas dos circulares em tempo real, bem como ver pontos
-importantes da faculdade, podem usar o aplicativo ''Guia USP", disponível para
+importantes da faculdade, podem usar o aplicativo ``Guia USP", disponível para
 Android e iOS.
 
 Para os bixes que não gostam de ler (preferem imagens) colocamos o
@@ -274,29 +274,29 @@ RG e, por garantia, o comprovante de vacinação em mãos, pois esses documentos
 podem ser solicitados principalmente nos horários de entrada controlada.
 \begin{itemize}
   \item {\bf Portaria 1 (P1):} R. Afrânio Peixoto. Funciona 24h por dia todos os
-    dias, mas a entrada é controlada para pedestres e carros nos seguintes
-    horários: todos os dias das 20h às 5h, aos sábados após as 14h, aos domingos
-    e feriados o dia inteiro. É por onde entram os ônibus municipais.
+  	dias, mas a entrada é controlada para pedestres e carros nos seguintes
+	horários: todos os dias das 20h às 5h, aos sábados após as 14h, aos domingos
+	e feriados o dia inteiro. É por onde entram os ônibus municipais.
 
   \item {\bf Portaria 2 (P2):} Av. Escola Politécnica. De segunda à sexta,
-  acesso livre das 5h às 20h e controlado das 20h às 0h. Aos sábados, acesso
-  somente para pedestres: liberado das 5h às 14h e controlado das 14h às 0h.
-  Fechada aos sábados (para veículos), domingos e feriados. Única entrada para
-  caminhões.
+  	acesso livre das 5h às 20h e controlado das 20h às 0h. Aos sábados, acesso
+	somente para pedestres: liberado das 5h às 14h e controlado das 14h às 0h.
+	Fechada aos sábados (para veículos), domingos e feriados. Única entrada para
+	caminhões.
 
   \item {\bf Portaria 3 (P3):} Av. Corifeu de Azevedo Marques. Tem o mesmo
   	horário de funcionamento do P1 para os pedestres. Para os carros, tem o
-  	mesmo horário do P1 exceto aos domingos, feriados e madrugadas (0h às 5h),
-  	nas quais ele fecha, ao contrário do P1.
+	mesmo horário do P1 exceto aos domingos, feriados e madrugadas (0h às 5h),
+	nas quais ele fecha, ao contrário do P1.
 
   \item {\bf Portaria P' (Plinha):} R. Eng. Teixeira Soares. Funciona de segunda
-  à sexta das 6h às 18h. Fechado de sábados, domingos e feriados.
+  	à sexta das 6h às 18h. Fechado de sábados, domingos e feriados.
 
   \item {\bf Portarias de pedestre (Mercadinho, São Remo, HU, CPTM e
-      Vila Indiana):} Funcionam de segunda à sexta das 5h às 20h, e de sábado
-      das 5h às 14h. Acesso controlado de segunda à sexta das 20h às 0h.
-      Nas portarias do Mercadinho e Vila Indiana, pode entrar em quaisquer
-      outros horários, incluindo domingos e feriados, mas o acesso é controlado.
+  	Vila Indiana):} Funcionam de segunda à sexta das 5h às 20h, e de sábado
+	das 5h às 14h. Acesso controlado de segunda à sexta das 20h às 0h.
+	Nas portarias do Mercadinho e Vila Indiana, pode entrar em quaisquer
+	outros horários, incluindo domingos e feriados, mas o acesso é controlado.
 
 \end{itemize}
 


### PR DESCRIPTION
Geral:
- Formatação das linhas até 80 caracteres
- Crases faltando (ex: segunda à sextas)
- Usar dois traços em vez de um (`--`) para fazer um travessão
- Correções gramaticais e de concordância (ex: manter o vocativo no plural em vez de ficar alternando "você" e "vocês")

Subseção Circulares:
- Retirei a piada de que circulares demoram "anos-luz" no domingo, pois é uma medida de distância e não de tempo
- Troca do aplicativo "Portões da USP", que pelo visto não existe mais, pelo Guia USP

Subseção Horários dos Portões:
- Reescrevi a parte que fala quais documentos ter, estava parecendo que você precisa de todos ao mesmo tempo. Além disso, acrescentei o comprovante de vacinação como garantia para o e-Card
- Reescrevi horário do P2 pois o "somente" usado antes estava confuso