### PR TITLE
TODO - Fazer menção sobre o BUSP provisório

### DIFF
--- a/src/sobre_o_ime.tex
+++ b/src/sobre_o_ime.tex
@@ -70,7 +70,7 @@ de Programação do BCC).
 \item {\bf Seção de Alunos:} é aqui que vocês vão resolver quase todos os
 pepinos de vocês durante a Graduação. Desde descobrir por que o Júpiterweb não
 quer matricular vocês em uma disciplina obrigatória até \sout{trancar essa mesma
-disciplina mais ou menos um mês depois} pegar o BUSP definitivo. %REFTIME (se em algum momento a matrícula presencial voltar a ser na seção de alunos, substituir o trecho sobre trancamento/BUSP pela data da matrícula)
+disciplina mais ou menos um mês depois} pegar o BUSP provisório e o definitivo. %REFTIME (se em algum momento a matrícula presencial voltar a ser na seção de alunos, substituir o trecho sobre trancamento/BUSP pela data da matrícula)
 
 A Seção de Alunos fica na sala 12, ao lado do CEC.
 \begin{itemize}


### PR DESCRIPTION
Faz menção a existência de um BUSP provisório, que pode ser retirado na Seção de Alunos