### PR TITLE
Update atitude_bixo.tex

### DIFF
--- a/src/atitude_bixo.tex
+++ b/src/atitude_bixo.tex
@@ -2,7 +2,7 @@
 \begin{secao}{Atitude, bixes!}
 \quadrinhos{7}
 
-Na USP, os alunos têm a liberdade e apoio de se organizarem
+Na USP, alunes têm a liberdade e apoio de se organizarem
 para montar grupos de debates, ciclos de palestras, grupos
 de desenvolvimento e até mesmo grupos para jogarem alguma coisa (como
 RPG, Magic, Yu-Gi-Oh ou algum esporte).
@@ -17,7 +17,7 @@ discutir aquele EP/lista de exercícios que ninguém está conseguindo
 fazer ou simplesmente estudar algum tópico de interesse mútuo.
 
 A seguir, temos (majoritariamente) alguns dos exemplos dos grupos que foram 
-direta ou indiretamente criados por alunos do nosso Instituto!
+direta ou indiretamente criados por alunes do nosso Instituto!
 
 % RDs --------------------------------------------------------------------------
 \input{rd.tex}


### PR DESCRIPTION
Correção de palavras discordantes com o gênero neutro (o pronome "seus" que faz referencia a "veteranes" também está discordante, mas as versões neutras mais usuais "sus" e "sues" podem ser entendidas como erros de digitação, então mantive a discordância)