### PR TITLE
Update beedata.tex

### DIFF
--- a/src/beedata.tex
+++ b/src/beedata.tex
@@ -5,7 +5,7 @@
 \textbf{Quem somos?}
 
 Uma organização de estudantes, profissionais e entusiastas em ciência
-de dados interessados em desenvolver habilidades técnicas valorosas para
+de dados interessades em desenvolver habilidades técnicas valorosas para
 esta área. Em particular, temos interesse no que chamamos de Ciência de
 Dados Competitiva, termo que abarca toda modalidade de competições e desafios
 que envolva a utilização dos conhecimentos que compõem o arcabouço técnico
@@ -22,13 +22,13 @@ interna quanto externamente.
 
 \textbf{Como nos organizamos?}
 
-É feita uma trilha de conhecimentos em ciência de dados para aqueles que não
-estão habituados com o assunto, reforçando tópicos básicos e importantes para dar
+É feita uma trilha de conhecimentos em ciência de dados para aquelus que não
+estão habituades com o assunto, reforçando tópicos básicos e importantes para dar
 prosseguimento nas competições.
 
 Mas via de regra, a participação em competições de ciência de dados se dá por meio
 de trabalho em equipe, com formação de times. Faz-se importante, portanto, que
-além do conhecimento técnico afiado os participantes saibam trabalhar em equipes.
+além do conhecimento técnico afiado es participantes saibam trabalhar em equipes.
 Nesse sentido, estruturamos nossa organização interna à partir da formação de
 pequenos grupos (4 a 5 pessoas), ao mesmo tempo autônomos para gerirem sua própria
 preparação, mas conectados pelo BeeData como canal de troca de experiências, produção


### PR DESCRIPTION
Correção de palavras discordantes com o gênero neutro (as menções de "membros" foram mantidas no masculino pois é mais comumente usado como substantivo sobrecomum masculino, apesar de existir a forma feminina "membra")