### PR TITLE
Update cec.tex

### DIFF
--- a/src/cec.tex
+++ b/src/cec.tex
@@ -18,7 +18,7 @@ escolares o horário de abertura é alterado para 9h00.
 O CEC possui 137 computadores, distribuídos em 04 (quatro) salas/laboratórios,
 sendo 02 (duas) delas com capacidade para até 60 pessoas e com prioridade de uso
 para as aulas de graduação do IME e para os cursos/treinamentos. Os outros
-laboratórios são utilizados pelos alunos de graduação dos cursos do IME para a
+laboratórios são utilizados por alunes de graduação dos cursos do IME para a
 realização dos trabalhos e pesquisas acadêmicas. Em todos os computadores o Sistema
 Operacional é o Linux Debian e possuem os aplicativos solicitados pelos docentes
 do Instituto.
@@ -28,7 +28,7 @@ do Instituto.
 \begin{subsecao}{Como funciona?}
 
 Possui rede cabeada e para utilizá-la é necessário ter uma senha de
-acesso (conta de usuário). Você precisa ser aluno matriculado no IME para
+acesso (conta de usuário). Você precisa ser alune matriculado no IME para
 solicitar a senha de uso, pois o CEC não é uma sala pró-aluno (para ver
 como as salas pró-aluno funcionam acesse \url{https://www.usp.br/proaluno/}). 
 Para solicitar a senha de acesso, envie e-mail para \url{cec-senha@ime.usp.br},
@@ -38,7 +38,7 @@ seu e-mail institucional (@usp.br - se esqueceu entre em
 
 \end{subsecao}
 
-\textbf{Obs.:} bixes, ao frequentarem o CEC, fiquem atentos ao ar-condicionado. Se
+\textbf{Obs.:} bixes, ao frequentarem o CEC, fiquem atentes ao ar-condicionado. Se
 estiver ligado, deem preferência a usarem calças, blusas, jaquetas e meias de
 lã. Cobertores são opcionais. Se não, boa sorte ou \textit{hasta la vista}!
 


### PR DESCRIPTION
Correção de palavras discordantes com o gênero neutro ("pró-aluno" mantido no masculino para melhor associação a página do site da USP)