### PR TITLE
correção circulares durante o fim de semana

### DIFF
--- a/src/transporte.tex
+++ b/src/transporte.tex
@@ -220,20 +220,21 @@ parte de vocês vão usar.
 
 {\bf Circulares durante finais de semana}
 
-Para chegar no IME a partir do metrô Butantã, vocês devem pegar o circular 1
-(8012-10). Se vocês pegarem o circular 2 (8022-10), em algum momento vocês 
-vão chegar no IME, mas o circular 1 é muito mais rápido.
+Durante os fins de semana e madrugadas, para chegar no IME 
+a partir do metrô Butantã, vocês devem pegar o 8012-10. 
+Se vocês pegarem o 8022-10, em algum momento vocês 
+vão chegar no IME, mas o 8012-10 é muito mais rápido.
 
-O circular 1 vai fazer o seguinte trajeto: Faculdade de Educação, CEPEUSP,
+O 8012-10 vai fazer o seguinte trajeto: Faculdade de Educação, CEPEUSP,
 Praça do Relógio Solar, Biblioteca Brasiliana e Faculdade de Economia,
 Administração e Contabilidade (FEA). A partir daí, deverão descer no ponto da
 FEA.
 
-Quando estiverem indo embora para o metrô, vocês devem pegar o circular 2
-(8022-10) no ponto da Oceanografia. CUIDADO: não peguem o circular 1 aqui
+Quando estiverem indo embora para o metrô, vocês devem pegar o 8022-10
+no ponto da Oceanografia. CUIDADO: não peguem o 8012-10 aqui
 se estiverem querendo ir para o metrô Butantã!!! Lembrem que ele passa na
 FEA logo no começo do trajeto (e provavelmente foi nesse ponto que vocês
-desceram do ônibus quando chegaram). Se vocês pegarem o circular 1 (8012-10)
+desceram do ônibus quando chegaram). Se vocês pegarem o 8012-10
 no ponto FAU I, também vão (em algum momento) chegar no metrô Butantã, mas
 boatos dizem que os outros circulares vão mais rápido. Aí, basta ficar no
 ônibus sentado (se conseguir um lugar!) até chegar no metrô Butantã, onde 


### PR DESCRIPTION
os circulares durante o fim de semana estavam como circular 1 e circular 2, mas esse ano escolhemos o 8082-10 e o 8083-10 como circular 1 e 2