### PR TITLE
TODO - Revisar seção "Apps"

### DIFF
--- a/utilidades.tex
+++ b/utilidades.tex
@@ -1,0 +1,91 @@
+\begin{secao}{Utilidades}
+
+\begin{subsecao}{Na WEB}
+
+\url{https://usp.br} - Página da USP. Aqui vocês encontrarão notícias e eventos da
+universidade, bem como informações gerais.
+
+\url{https://ime.usp.br} - Página do IME. Nesse link, vocês poderão ver detalhes sobre
+os cursos e obter informações sobre a faculdade.
+
+\url{https://uspdigital.usp.br/jupiterweb} - Sistema JúpiterWeb. Aqui vocês vão
+encontrar a grade horária e, mais tarde, poderão fazer matrícula nas matérias
+que irão cursar no semestre. Além disso, podem acompanhar o pagamento de
+bolsas e auxílios por ele e também ter acesso ao seu histórico escolar com
+as suas notas.
+
+\url{https://portalservicos.usp.br} ou \url{https://olimpo.usp.br} - Portal com todos os
+serviços digitais da USP. Vocês vão reparar que a aba ``Graduação'' na verdade
+é o JúpiterWeb disfarçado, então na prática vocês podem só acessar o link acima
+que dá na mesma (só é um pouco menos bonito porque é um site mais antigo).
+
+\url{https://edisciplinas.usp.br} - É bixes\dots Acham que vai ser essa moleza pra
+sempre? Se vocês acham, estão muito enganados! Daqui a pouco vocês vão receber
+uma senha para poder enviar seus EPs (vide glossário) nesse endereço\dots
+(e não adianta fazerem chantagem emocional que o e-Disciplinas só vai aceitar
+até 23h59\dots Não entendeu? Vocês vão entender\dots)
+
+\url{https://instagram.com/spottedimeusp/} - Viu alguém interessante? Quer mandar uma
+cantada pro crush, mas tem vergonha? Manda um spotted! Afinal, só o $x$ deve
+ficar isolado. Ou achou alguém bacana e com gostos parecidos, que tal mandar um
+spotted para fazer novas amizades?
+
+\url{https://www.instagram.com/usp_spotted/} - Spotted da USP. Serve para a mesma
+coisa que o Spotted do IME, só que é para USP toda.
+
+% \url{ www.xkcd.com} - Webcomic sobre matemática e computação. Origem de muitas
+% piadas que vocês ouvirão por aí.
+
+E por fim\dots
+
+\url{https://google.com.br} - Tudo o que vocês precisam tá no google. Se não
+estiver, então não existe. Aproveitem e procurem o Código de Ética da USP (ou
+baixem ele em \url{http://www.prg.usp.br/wp-content/uploads/CodigoEtica.pdf})
+
+\end{subsecao}
+
+\begin{subsecao}{Apps}
+	
+Alguns dos apps disponíveis na AppStore e PlayStore oferecidos pela própria USP
+que podem ajudar. Para ver a lista completa, procure pelo desenvolvedor
+``Universidade de São Paulo'' em qualquer uma das duas lojas.
+
+{\bf e-Card USP} - Esse é o app mais importante nesse começo de ano, enquanto
+sua carteirinha não chega (ver seção Cartão USP no Júpiter). O aplicativo é uma
+carteirinha virtual que te dá acesso a tudo que o cartão físico permite,
+inclusive comer no bandejão.
+
+{\bf Cardápio+ USP} - Contém o cardápio dos bandejões e mais outros serviços
+da SAS, como creche, saúde mental e moradia. Lá vocês também poderão conferir 
+se o bandejão está fechado ou funcionando com o horário reduzido.
+
+{\bf Guia USP} - Mapa dos principais lugares da USP, incluindo os institutos,
+restaurantes, bancos e mais. Mostra a localização dos circulares em tempo quase
+real, mas não é muito preciso e às vezes trava.
+
+{\bf Campus USP} - Permite acessar a central da Guarda Universitária
+diretamente no caso de uma emergência. Contém um mapa com as ocorrências
+recentes de segurança.
+
+{\bf Disque Trote USP} - Use esse app para denunciar caso sofra um trote
+violento. Se preferir conversar mesmo, também pode ligar para o número de
+telefone que está mais embaixo.
+
+\end{subsecao}
+
+\begin{subsecao}{Telefones}
+
+{\bf Disque Trote:} {\tt 0800-012-1090} --
+\underline{Não deixe de ligar se você sofrer algum trote violento!!}
+
+{\bf SAS:} Seção de Passe Escolar: {\tt (11) 2648-1863} ou {\tt (11) 2648-1865}
+
+{\bf Serviço de Graduação do IME (mais conhecido como Seção de Alunos):} {\tt (11) 3091-6149}
+
+{\bf Superintendência de Tecnologia da Informação (STI):} {\tt (11) 3091-6400}
+
+%{\bf Plantão de Cálculo e Álgebra Linear (serviço gratuito):} {\tt 3037-1773}
+%Diziam que era o orelhão do ime, vai que isso volta, resolvi só comentar^^
+
+\end{subsecao}
+\end{secao}


### PR DESCRIPTION
Sem alterações, a seção já contém todos os apps relevantes para a graduação. Outros apps da USP que não estão no guia são:

Entreartes (exclusivo para IOS): sistema de prêmios e brindes para incentivar a ir em atividades culturais da USP. Não foi adicionado por ser exclusivo para IOS.
 
Assistente Janus: para o pessoal da pós, não é para os bixes.

Patrimônio USP: cuida dos objetos da USP com aqueles códigos de barra de patrimônio, não parece ser um app para alunos.

Digitavox USP: curso de digitação para pessoas com deficiência visual. Testei a acessibilidade do PDF do guia com o Pdf Acessibility Checker (PAC,  https://pac.pdf-accessibility.org/en) e deu como não acessível. Não acho que é educado colocar o App no guia se o PDF não é acessível.