### PR TITLE
TODO - Revisar seção "O SAS"

### DIFF
--- a/src/sobre_a_usp.tex
+++ b/src/sobre_a_usp.tex
@@ -187,7 +187,7 @@ Será nesse lugar que você resolverá boa parte dos seus problemas com a PRIP e
 Bilhete Único. Você pode se dirigir ao Bloco “E” do CRUSP para receber orientação sobre
 as mais diversas burocracias em que está se metendo.
 
-Para as linhas da EMTU, SPTRANS, METRO, vocês devem entrar no site do PRIP e fazer
+Para as linhas da EMTU, SPTRANS, METRO, vocês devem entrar no site da PRIP e fazer
 o cadastro para o respectivo cartão (\url {https://prip.usp.br/servicos/transporte/}) 
 para que a USP envie os seus dados para as empresas de transporte. Talvez demore um pouco, 
 pois a USP tem que avisar para a SPTrans que vocês passaram na Fuvest. Fiquem atentos! 


### PR DESCRIPTION
- Mudança de "SAS" para "PRIP", dado que a pró reitoria foi criada com para acoplar o SAS a outros órgãos e unificar tudo.
- Gramática.
- Atualização da maior parte dos links, que antes eram do SAS e enviava pra uns sites que nem existem mais, para os devidos sites da PRIP.
- Atualização do serviço odontológico, que trocou de link e funciona de outra forma.
- Atualização do passe, que agora funciona de outra forma.
* Alterei muita coisa de uma vez e tem muita informação nova por conta que essa parte não era alterada desde 2021 pelo o que eu entendi, se os revisores puderem olhar novamente o texto principalmente gramaticalmente, agradeço.