### PR TITLE
TODO - Revisar seção "Eduroam"

### DIFF
--- a/src/sobre_a_usp.tex
+++ b/src/sobre_a_usp.tex
@@ -93,8 +93,6 @@ Tem várias outras informações sobre as configurações na hora de fazer login
 \sout{ninguém entende, mas se algum de vocês entender,} estão no site
 \url{https://eduroam.usp.br/como-usar/}. Nesse site também tem alguns programas para Windows que 
 configuram o Eduroam automaticamente. (Dica: se for baixar eles, utilize o Instalador Alternativo) %REFTIME
-Também existem cartazes espalhados pelo IME com os detalhes de login para diferentes tipos de 
-dispositivo, então deem uma olhada nas paredes.
 
 \end{subsecao}
 


### PR DESCRIPTION
- As informações no texto como um todo estão certas e realmente, o instalador alternativo pode ser melhor principalmente em computadores antigos, então não vejo porque tirar a informação.
- Sobre a parte dos cartazes, nunca vi isso e nunca vi ninguém falando disso, provavelmente antigamente tinha mas o IME deve ter tirado pra colocar outros cartazes ou algo do tipo.