### PR TITLE
TODO - Revisar seção "Grupos no Whatsapp"

### DIFF
--- a/src/sobre_a_usp.tex
+++ b/src/sobre_a_usp.tex
@@ -57,11 +57,13 @@ sites institucionais ou simplesmente não usam a internet para nada.
 
 Com o intuito de organizar as atividades referentes a uma disciplina e ser uma
 maneira prática e efetiva de passar recados, costumamos utilizar grupos do WhatsApp
-para cada uma das matérias. Caso os links ainda não tenham sido criados,
-vale a pena juntar seus amigos para criar os grupos no começo do semestre e espalhar
-para os outros alunos.
+para cada uma das matérias. Para o BCC, os grupos costumam ser criados no Telegram.
+Os grupos são organizados em planilhas com seus respectivos códigos e nomes, para manter a organização. 
+Caso os links ainda não tenham sido criados, vale a pena juntar seus amigos para criar os grupos no começo 
+do semestre e espalhar para os outros alunos.
+As planilhas com os links dos grupos geralmente são compartilhadas nos próprios grupos/comunidade dos cursos!
 
-Dentre as principais funções do grupo do WhatsApp estão:
+Dentre as principais funções do grupo do WhatsApp/Telegram estão:
 
 \begin{enumerate}
 %\item Colocar o link para acessar a plataforma on-line das aulas na descrição pra facilitar pra todo mundo;
@@ -71,7 +73,7 @@ Dentre as principais funções do grupo do WhatsApp estão:
 \end{enumerate}
 
 Pra ficar por dentro de tudo o que acontece na matéria, não se esqueça de procurar o
-link e fazer parte dos grupos de whats das matérias que você está cursando!! :)
+link e fazer parte dos grupos das matérias que você está cursando!! :)
 
 \end{subsecao}
 


### PR DESCRIPTION
Revisei, adicionei a informação de que os grupos do BCC geralmente ficam no telegram e que os grupos geralmente são passados nas próprias comunidades dos cursos.